### PR TITLE
Make the Free Parking pot configurable

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -93,6 +93,7 @@ const App: React.FC = () => {
                 playerId={game.playerId}
                 isGameOpen={game.open}
                 players={game.players}
+                useFreeParking={game.useFreeParking}
                 freeParkingBalance={game.freeParkingBalance}
                 proposeTransaction={game.actions.proposeTransaction}
                 events={game.events}
@@ -106,6 +107,7 @@ const App: React.FC = () => {
               routePaths.bank,
               <Bank
                 players={game.players}
+                useFreeParking={game.useFreeParking}
                 freeParkingBalance={game.freeParkingBalance}
                 hasATransactionBeenMade={
                   game.events.filter((e) => e.type === "transaction").length > 0
@@ -125,10 +127,12 @@ const App: React.FC = () => {
               routePaths.settings,
               <Settings
                 isGameOpen={game.open}
+                useFreeParking={game.useFreeParking}
                 players={game.players}
                 proposePlayerNameChange={game.actions.proposePlayerNameChange}
                 proposePlayerDelete={game.actions.proposePlayerDelete}
                 proposeGameOpenStateChange={game.actions.proposeGameOpenStateChange}
+                proposeUseFreeParkingChange={game.actions.proposeUseFreeParkingChange}
                 proposeGameEnd={game.actions.proposeGameEnd}
               />
             )

--- a/packages/client/src/hooks/useGameHandler.tsx
+++ b/packages/client/src/hooks/useGameHandler.tsx
@@ -21,6 +21,7 @@ export interface IGameHandlerState extends IGameState {
     proposePlayerNameChange: (playerId: string, name: string) => void;
     proposePlayerDelete: (playerId: string) => void;
     proposeGameOpenStateChange: (open: boolean) => void;
+    proposeUseFreeParkingChange: (useFreeParking: boolean) => void;
     proposeGameEnd: () => void;
   };
 }
@@ -48,7 +49,9 @@ const useGameHandler = (): {
                 {player.name}: {formatCurrency(player.balance)}
               </li>
             ))}
+            {gameState.useFreeParking &&
             <li>Free Parking: {formatCurrency(gameState.freeParkingBalance)}</li>
+            }
           </ul>
           <small>(Provided just in the case you need to re-create the game)</small>
         </>
@@ -104,6 +107,7 @@ const useGameHandler = (): {
               proposePlayerNameChange: gameHandler.proposePlayerNameChange.bind(gameHandler),
               proposePlayerDelete: gameHandler.proposePlayerDelete.bind(gameHandler),
               proposeGameOpenStateChange: gameHandler.proposeGameOpenStateChange.bind(gameHandler),
+              proposeUseFreeParkingChange: gameHandler.proposeUseFreeParkingChange.bind(gameHandler),
               proposeGameEnd: gameHandler.proposeGameEnd.bind(gameHandler)
             }
           }

--- a/packages/client/src/logic/GameHandler.ts
+++ b/packages/client/src/logic/GameHandler.ts
@@ -7,7 +7,8 @@ import {
   ITransactionEvent,
   IPlayerNameChangeEvent,
   IPlayerDeleteEvent,
-  IGameOpenStateChangeEvent
+  IGameOpenStateChangeEvent,
+  IUseFreeParkingChangeEvent
 } from "@monopoly-money/game-state";
 import config from "../config";
 import {
@@ -150,6 +151,17 @@ class GameHandler {
       actionedBy: "", // Will be filled in by the server
       type: "gameOpenStateChange",
       open
+    };
+    this.submitEvent(event);
+  }
+
+  // Enable / disable Free Parking house rule
+  public proposeUseFreeParkingChange(useFreeParking: boolean) {
+    const event: IUseFreeParkingChangeEvent = {
+      time: "", // Will be filled in by the server
+      actionedBy: "", // Will be filled in by the server
+      type: "useFreeParkingChange",
+      useFreeParking
     };
     this.submitEvent(event);
   }

--- a/packages/client/src/pages/Bank/index.tsx
+++ b/packages/client/src/pages/Bank/index.tsx
@@ -8,6 +8,7 @@ import PlayerPassedGo from "./PlayerPassedGo";
 
 interface IBankProps {
   players: IGameStatePlayer[];
+  useFreeParking: boolean;
   freeParkingBalance: number;
   hasATransactionBeenMade: boolean;
   proposeTransaction: (from: GameEntity, to: GameEntity, amount: number) => void;
@@ -15,6 +16,7 @@ interface IBankProps {
 
 const Bank: React.FC<IBankProps> = ({
   players,
+  useFreeParking,
   freeParkingBalance,
   hasATransactionBeenMade,
   proposeTransaction
@@ -47,6 +49,7 @@ const Bank: React.FC<IBankProps> = ({
         />
       </div>
 
+      {useFreeParking &&
       <div className="mb-4">
         <GiveFreeParking
           players={players}
@@ -56,6 +59,7 @@ const Bank: React.FC<IBankProps> = ({
           }
         />
       </div>
+      }
 
       <div className="mb-4">
         <ValuePlayerForm

--- a/packages/client/src/pages/Funds/index.tsx
+++ b/packages/client/src/pages/Funds/index.tsx
@@ -15,6 +15,7 @@ interface IFundsProps {
   playerId: string;
   isGameOpen: boolean;
   players: IGameStatePlayer[];
+  useFreeParking: boolean;
   freeParkingBalance: number;
   proposeTransaction: (from: GameEntity, to: GameEntity, amount: number) => void;
   events: GameEvent[];
@@ -25,6 +26,7 @@ const Funds: React.FC<IFundsProps> = ({
   playerId,
   isGameOpen,
   players,
+  useFreeParking,
   freeParkingBalance,
   proposeTransaction,
   events
@@ -86,12 +88,14 @@ const Funds: React.FC<IFundsProps> = ({
       </div>
 
       <div className="balance-grid">
+        {useFreeParking &&
         <PlayerCard
           name={freeParkingName}
           connected={null}
           balance={freeParkingBalance}
           onClick={() => setRecipient("freeParking")}
         />
+        }
         <PlayerCard
           name={bankName}
           connected={null}

--- a/packages/client/src/pages/History/index.tsx
+++ b/packages/client/src/pages/History/index.tsx
@@ -152,6 +152,17 @@ const getEventDetails = (
       };
     }
 
+    case "useFreeParkingChange": {
+      const actionedBy = previousState.players.find((p) => p.playerId === event.actionedBy)!;
+      return {
+        ...defaults,
+        title: "Use Free Parking State Change",
+        actionedBy: actionedBy.name,
+        detail: `The Free Parking house rule is now ${event.useFreeParking ? "enabled" : "disabled"}`,
+        colour: "blue"
+      };
+    }
+
     case "playerConnectionChange": {
       // Don't show these as they will pollute the history
       // const playerName = previousState.players.find((p) => p.playerId === event.playerId)!.name;

--- a/packages/client/src/pages/Home/index.tsx
+++ b/packages/client/src/pages/Home/index.tsx
@@ -72,7 +72,7 @@ const Home: React.FC<IHomeProps> = ({ onGameSetup }) => {
                             {player.name}: {formatCurrency(player.balance)}
                           </Badge>
                         ))}
-                      {status !== null && (
+                      {status !== null && status.useFreeParking && (
                         <Badge variant="warning">
                           Free Parking: {formatCurrency(status.freeParkingBalance)}
                         </Badge>

--- a/packages/client/src/pages/Settings/index.tsx
+++ b/packages/client/src/pages/Settings/index.tsx
@@ -11,19 +11,23 @@ import ConnectedStateDot from "../../components/ConnectedStateDot";
 
 interface ISettingsProps {
   isGameOpen: boolean;
+  useFreeParking: boolean;
   players: IGameStatePlayer[];
   proposePlayerNameChange: (playerId: string, name: string) => void;
   proposePlayerDelete: (playerId: string) => void;
   proposeGameOpenStateChange: (open: boolean) => void;
+  proposeUseFreeParkingChange: (useFreeParking: boolean) => void;
   proposeGameEnd: () => void;
 }
 
 const Settings: React.FC<ISettingsProps> = ({
   isGameOpen,
+  useFreeParking,
   players,
   proposePlayerNameChange,
   proposePlayerDelete,
   proposeGameOpenStateChange,
+  proposeUseFreeParkingChange,
   proposeGameEnd
 }) => {
   const [actioningPlayer, setActioningPlayer] = useState<IGameStatePlayer | null>(null);
@@ -116,6 +120,10 @@ const Settings: React.FC<ISettingsProps> = ({
           ))}
         </tbody>
       </Table>
+
+      <Button block variant="info" onClick={() => proposeUseFreeParkingChange(!useFreeParking)}>
+        {useFreeParking ? "Disable" : "Enable"} the Free Parking House Rule
+      </Button>
 
       <Button block variant="primary" onClick={() => proposeGameOpenStateChange(!isGameOpen)}>
         {isGameOpen ? "Close" : "Open"} Game To New Players

--- a/packages/game-state/src/index.ts
+++ b/packages/game-state/src/index.ts
@@ -11,6 +11,7 @@ import {
   IPlayerBankerStatusChangeEvent,
   ITransactionEvent,
   IGameOpenStateChangeEvent,
+  IUseFreeParkingChangeEvent,
   IPlayerConnectionChangeEvent
 } from "./types";
 
@@ -28,5 +29,6 @@ export {
   IPlayerBankerStatusChangeEvent,
   ITransactionEvent,
   IGameOpenStateChangeEvent,
+  IUseFreeParkingChangeEvent,
   IPlayerConnectionChangeEvent
 };

--- a/packages/game-state/src/state.ts
+++ b/packages/game-state/src/state.ts
@@ -2,6 +2,7 @@ import { GameEvent, IGameState } from "./types";
 
 export const defaultGameState: IGameState = {
   players: [],
+  useFreeParking: true,
   freeParkingBalance: 0,
   open: true
 };
@@ -120,6 +121,12 @@ export const calculateGameState = (events: GameEvent[], currentState: IGameState
         return {
           ...state,
           open: event.open
+        };
+
+      case "useFreeParkingChange":
+        return {
+          ...state,
+          useFreeParking: event.useFreeParking
         };
 
       case "playerConnectionChange":

--- a/packages/game-state/src/types.ts
+++ b/packages/game-state/src/types.ts
@@ -13,6 +13,7 @@ export interface IGameStatePlayer {
 
 export interface IGameState {
   players: IGameStatePlayer[];
+  useFreeParking: boolean;
   freeParkingBalance: number;
   open: boolean;
 }
@@ -26,6 +27,7 @@ export type GameEvent =
   | IPlayerBankerStatusChangeEvent
   | ITransactionEvent
   | IGameOpenStateChangeEvent
+  | IUseFreeParkingChangeEvent
   | IPlayerConnectionChangeEvent;
 
 export interface IGameEvent {
@@ -66,6 +68,11 @@ export interface ITransactionEvent extends IGameEvent {
 export interface IGameOpenStateChangeEvent extends IGameEvent {
   type: "gameOpenStateChange";
   open: boolean;
+}
+
+export interface IUseFreeParkingChangeEvent extends IGameEvent {
+  type: "useFreeParkingChange";
+  useFreeParking: boolean;
 }
 
 export interface IPlayerConnectionChangeEvent extends IGameEvent {


### PR DESCRIPTION
In Monopoly, the Free Parking pot is an optional rule.

This PR adds a state flag to manage the visibility of the pot in the client; the bank can disable or re-enable it, and the Free Parking UI options for players and bank appear and disappear accordingly. The pot value is never cleared, in case disabling it was an error.

This should address #12
