### PR TITLE
#59 Add setting to hide opposition balances

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -112,6 +112,7 @@ const App: React.FC = () => {
                 players={game.players}
                 useFreeParking={game.useFreeParking}
                 freeParkingBalance={game.freeParkingBalance}
+                showOppositionBalances={game.showOppositionBalances}
                 proposeTransaction={game.actions.proposeTransaction}
                 events={game.events}
               />
@@ -145,11 +146,15 @@ const App: React.FC = () => {
               <Settings
                 isGameOpen={game.open}
                 useFreeParking={game.useFreeParking}
+                showOppositionBalances={game.showOppositionBalances}
                 players={game.players}
                 proposePlayerNameChange={game.actions.proposePlayerNameChange}
                 proposePlayerDelete={game.actions.proposePlayerDelete}
                 proposeGameOpenStateChange={game.actions.proposeGameOpenStateChange}
                 proposeUseFreeParkingChange={game.actions.proposeUseFreeParkingChange}
+                proposeShowOppositionBalancesChange={
+                  game.actions.proposeShowOppositionBalancesChange
+                }
                 proposeGameEnd={game.actions.proposeGameEnd}
               />
             )
@@ -157,16 +162,19 @@ const App: React.FC = () => {
     [routePaths.help]: () => wrapRoute(routePaths.help, <Help />)
   };
 
-  const routesWithTrailingSlashes = Object.keys(routes).reduce((acc, route) => {
-    const extendedRoutes = getExtendedRoutes(route);
-    return {
-      ...acc,
-      ...extendedRoutes.reduce(
-        (acc1, extendedRoute) => ({ ...acc1, [extendedRoute]: routes[route] }),
-        {}
-      )
-    };
-  }, {} as { [key: string]: () => JSX.Element });
+  const routesWithTrailingSlashes = Object.keys(routes).reduce(
+    (acc, route) => {
+      const extendedRoutes = getExtendedRoutes(route);
+      return {
+        ...acc,
+        ...extendedRoutes.reduce(
+          (acc1, extendedRoute) => ({ ...acc1, [extendedRoute]: routes[route] }),
+          {}
+        )
+      };
+    },
+    {} as { [key: string]: () => JSX.Element }
+  );
 
   const routeResult = useRoutes(routesWithTrailingSlashes);
 

--- a/packages/client/src/hooks/useGameHandler.tsx
+++ b/packages/client/src/hooks/useGameHandler.tsx
@@ -22,6 +22,7 @@ export interface IGameHandlerState extends IGameState {
     proposePlayerDelete: (playerId: string) => void;
     proposeGameOpenStateChange: (open: boolean) => void;
     proposeUseFreeParkingChange: (useFreeParking: boolean) => void;
+    proposeShowOppositionBalancesChange: (showOppositionBalances: boolean) => void;
     proposeGameEnd: () => void;
   };
 }
@@ -109,6 +110,8 @@ const useGameHandler = (): {
               proposeGameOpenStateChange: gameHandler.proposeGameOpenStateChange.bind(gameHandler),
               proposeUseFreeParkingChange:
                 gameHandler.proposeUseFreeParkingChange.bind(gameHandler),
+              proposeShowOppositionBalancesChange:
+                gameHandler.proposeShowOppositionBalancesChange.bind(gameHandler),
               proposeGameEnd: gameHandler.proposeGameEnd.bind(gameHandler)
             }
           }

--- a/packages/client/src/logic/GameHandler.ts
+++ b/packages/client/src/logic/GameHandler.ts
@@ -7,6 +7,7 @@ import {
   IGameState,
   IPlayerDeleteEvent,
   IPlayerNameChangeEvent,
+  IShowOppositionBalancesChangeEvent,
   ITransactionEvent,
   IUseFreeParkingChangeEvent
 } from "@monopoly-money/game-state";
@@ -162,6 +163,17 @@ class GameHandler {
       actionedBy: "", // Will be filled in by the server
       type: "useFreeParkingChange",
       useFreeParking
+    };
+    this.submitEvent(event);
+  }
+
+  // Show / hide opposition balances
+  public proposeShowOppositionBalancesChange(showOppositionBalances: boolean) {
+    const event: IShowOppositionBalancesChangeEvent = {
+      time: "", // Will be filled in by the server
+      actionedBy: "", // Will be filled in by the server
+      type: "showOppositionBalancesChange",
+      showOppositionBalances
     };
     this.submitEvent(event);
   }

--- a/packages/client/src/pages/Funds/PlayerCard.tsx
+++ b/packages/client/src/pages/Funds/PlayerCard.tsx
@@ -6,7 +6,7 @@ import { formatCurrency } from "../../utils";
 interface IPlayerCardProps {
   name: string;
   connected: boolean | null;
-  balance: number;
+  balance: number | null;
   onClick: () => void;
 }
 
@@ -16,7 +16,7 @@ const PlayerCard: React.FC<IPlayerCardProps> = ({ name, connected, balance, onCl
       {connected !== null && <ConnectedStateDot connected={connected} className="m-2" />}
       <Card.Body className="p-3" onClick={onClick}>
         <div>{name}</div>
-        <div>{Number.isFinite(balance) ? formatCurrency(balance) : "∞"}</div>
+        {balance !== null && <div>{Number.isFinite(balance) ? formatCurrency(balance) : "∞"}</div>}
       </Card.Body>
     </Card>
   );

--- a/packages/client/src/pages/Funds/index.tsx
+++ b/packages/client/src/pages/Funds/index.tsx
@@ -16,6 +16,7 @@ interface IFundsProps {
   isGameOpen: boolean;
   players: IGameStatePlayer[];
   useFreeParking: boolean;
+  showOppositionBalances: boolean;
   freeParkingBalance: number;
   proposeTransaction: (from: GameEntity, to: GameEntity, amount: number) => void;
   events: GameEvent[];
@@ -28,6 +29,7 @@ const Funds: React.FC<IFundsProps> = ({
   players,
   useFreeParking,
   freeParkingBalance,
+  showOppositionBalances,
   proposeTransaction,
   events
 }) => {
@@ -81,7 +83,7 @@ const Funds: React.FC<IFundsProps> = ({
             key={player.playerId}
             name={player.name}
             connected={player.connected}
-            balance={player.balance}
+            balance={showOppositionBalances ? player.balance : null}
             onClick={() => setRecipient(player)}
           />
         ))}

--- a/packages/client/src/pages/History/index.tsx
+++ b/packages/client/src/pages/History/index.tsx
@@ -95,14 +95,14 @@ const getEventDetails = (
         event.to === "bank"
           ? bankName
           : event.to === "freeParking"
-          ? freeParkingName
-          : nextState.players.find((p) => p.playerId === event.to)!.name;
+            ? freeParkingName
+            : nextState.players.find((p) => p.playerId === event.to)!.name;
       const playerGiving =
         event.from === "bank"
           ? bankName
           : event.from === "freeParking"
-          ? freeParkingName
-          : nextState.players.find((p) => p.playerId === event.from)!.name;
+            ? freeParkingName
+            : nextState.players.find((p) => p.playerId === event.from)!.name;
       const actionedBy = previousState.players.find((p) => p.playerId === event.actionedBy)!;
       return {
         ...defaults,
@@ -162,6 +162,17 @@ const getEventDetails = (
         detail: `The Free Parking house rule is now ${
           event.useFreeParking ? "enabled" : "disabled"
         }`,
+        colour: "blue"
+      };
+    }
+
+    case "showOppositionBalancesChange": {
+      const actionedBy = previousState.players.find((p) => p.playerId === event.actionedBy)!;
+      return {
+        ...defaults,
+        title: "Show Opposition Balances State Change",
+        actionedBy: actionedBy.name,
+        detail: `Opposition balances are now ${event.showOppositionBalances ? "shown" : "hidden"}`,
         colour: "blue"
       };
     }

--- a/packages/client/src/pages/Settings/index.tsx
+++ b/packages/client/src/pages/Settings/index.tsx
@@ -9,7 +9,9 @@ import {
   trackFreeParkingDisabled,
   trackFreeParkingEnabled,
   trackNewPlayersAllowed,
-  trackNewPlayersNotAllowed
+  trackNewPlayersNotAllowed,
+  trackShowOppositionBalancesDisabled,
+  trackShowOppositionBalancesEnabled
 } from "../../utils";
 import DeletePlayerModal from "./DeletePlayerModal";
 import EndGameConfirmDialog from "./EndGameConfirmDialog";
@@ -19,22 +21,26 @@ import "./Settings.scss";
 interface ISettingsProps {
   isGameOpen: boolean;
   useFreeParking: boolean;
+  showOppositionBalances: boolean;
   players: IGameStatePlayer[];
   proposePlayerNameChange: (playerId: string, name: string) => void;
   proposePlayerDelete: (playerId: string) => void;
   proposeGameOpenStateChange: (open: boolean) => void;
   proposeUseFreeParkingChange: (useFreeParking: boolean) => void;
+  proposeShowOppositionBalancesChange: (showOppositionBalances: boolean) => void;
   proposeGameEnd: () => void;
 }
 
 const Settings: React.FC<ISettingsProps> = ({
   isGameOpen,
   useFreeParking,
+  showOppositionBalances,
   players,
   proposePlayerNameChange,
   proposePlayerDelete,
   proposeGameOpenStateChange,
   proposeUseFreeParkingChange,
+  proposeShowOppositionBalancesChange,
   proposeGameEnd
 }) => {
   const [actioningPlayer, setActioningPlayer] = useState<IGameStatePlayer | null>(null);
@@ -74,6 +80,15 @@ const Settings: React.FC<ISettingsProps> = ({
     ),
     [actioningPlayer]
   );
+
+  const toggleShowOppositionBalances = () => {
+    if (showOppositionBalances) {
+      trackShowOppositionBalancesDisabled();
+    } else {
+      trackShowOppositionBalancesEnabled();
+    }
+    proposeShowOppositionBalancesChange(!showOppositionBalances);
+  };
 
   const toggleFreeParking = () => {
     if (useFreeParking) {
@@ -145,6 +160,10 @@ const Settings: React.FC<ISettingsProps> = ({
           ))}
         </tbody>
       </Table>
+
+      <Button block variant="info" onClick={toggleShowOppositionBalances}>
+        {showOppositionBalances ? "Hide" : "Show"} opposition balances
+      </Button>
 
       <Button block variant="info" onClick={toggleFreeParking}>
         {useFreeParking ? "Disable" : "Enable"} the Free Parking House Rule

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -54,6 +54,12 @@ export const trackFreeParkingDisabled = () => tryToTrackGAEvent("Free parking di
 
 export const trackFreeParkingEnabled = () => tryToTrackGAEvent("Free parking enabled");
 
+export const trackShowOppositionBalancesDisabled = () =>
+  tryToTrackGAEvent("Show opposition balances disabled");
+
+export const trackShowOppositionBalancesEnabled = () =>
+  tryToTrackGAEvent("Show opposition balances enabled");
+
 export const trackNewPlayersNotAllowed = () => tryToTrackGAEvent("New players not allowed");
 
 export const trackNewPlayersAllowed = () => tryToTrackGAEvent("New players allowed");

--- a/packages/game-state/src/index.ts
+++ b/packages/game-state/src/index.ts
@@ -10,6 +10,7 @@ import {
   IPlayerDeleteEvent,
   IPlayerJoinEvent,
   IPlayerNameChangeEvent,
+  IShowOppositionBalancesChangeEvent,
   ITransactionEvent,
   IUseFreeParkingChangeEvent,
   PlayerId
@@ -28,6 +29,7 @@ export {
   IPlayerDeleteEvent,
   IPlayerJoinEvent,
   IPlayerNameChangeEvent,
+  IShowOppositionBalancesChangeEvent,
   ITransactionEvent,
   IUseFreeParkingChangeEvent,
   PlayerId

--- a/packages/game-state/src/state.ts
+++ b/packages/game-state/src/state.ts
@@ -3,6 +3,7 @@ import { GameEvent, IGameState } from "./types";
 export const defaultGameState: IGameState = {
   players: [],
   useFreeParking: true,
+  showOppositionBalances: true,
   freeParkingBalance: 0,
   open: true
 };
@@ -127,6 +128,12 @@ export const calculateGameState = (events: GameEvent[], currentState: IGameState
         return {
           ...state,
           useFreeParking: event.useFreeParking
+        };
+
+      case "showOppositionBalancesChange":
+        return {
+          ...state,
+          showOppositionBalances: event.showOppositionBalances
         };
 
       case "playerConnectionChange":

--- a/packages/game-state/src/types.ts
+++ b/packages/game-state/src/types.ts
@@ -14,6 +14,7 @@ export interface IGameStatePlayer {
 export interface IGameState {
   players: IGameStatePlayer[];
   useFreeParking: boolean;
+  showOppositionBalances: boolean;
   freeParkingBalance: number;
   open: boolean;
 }
@@ -28,6 +29,7 @@ export type GameEvent =
   | ITransactionEvent
   | IGameOpenStateChangeEvent
   | IUseFreeParkingChangeEvent
+  | IShowOppositionBalancesChangeEvent
   | IPlayerConnectionChangeEvent;
 
 export interface IGameEvent {
@@ -73,6 +75,11 @@ export interface IGameOpenStateChangeEvent extends IGameEvent {
 export interface IUseFreeParkingChangeEvent extends IGameEvent {
   type: "useFreeParkingChange";
   useFreeParking: boolean;
+}
+
+export interface IShowOppositionBalancesChangeEvent extends IGameEvent {
+  type: "showOppositionBalancesChange";
+  showOppositionBalances: boolean;
 }
 
 export interface IPlayerConnectionChangeEvent extends IGameEvent {


### PR DESCRIPTION
This adds a setting which allows admins to toggle on/off opposition balances. Having this off will hide opposition account values under their name on the funds page.